### PR TITLE
feat: add `StorageClient` trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
-    "storage-node"
+    "storage-node",
+    "storage-client"
 ]
 
 resolver = "2"

--- a/storage-client/Cargo.toml
+++ b/storage-client/Cargo.toml
@@ -6,6 +6,9 @@ edition = "2021"
 [dependencies]
 arrow = "50"
 anyhow = "1"
-hyper = "1.1.0"
+hyper = "1"
 datafusion = "35"
 async-trait = "0.1"
+tokio = { version = "1", features = [
+    "sync"
+] }

--- a/storage-client/Cargo.toml
+++ b/storage-client/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "storage-client"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+arrow = "50"
+anyhow = "1"
+hyper = "1.1.0"
+datafusion = "35"
+async-trait = "0.1"

--- a/storage-client/src/client.rs
+++ b/storage-client/src/client.rs
@@ -1,0 +1,48 @@
+use arrow::record_batch::RecordBatch;
+use datafusion::{error::DataFusionError, physical_plan::SendableRecordBatchStream};
+use hyper::Uri;
+
+use crate::{StorageClient, StorageRequest, StorageResult};
+
+pub struct StorageClientImpl {
+    _storage_server_endpoint: Uri,
+    _catalog_server_endpoint: Uri,
+}
+
+impl StorageClientImpl {
+    pub fn new(
+        storage_server_endpoint_str: &str,
+        catalog_server_endpoint_str: &str,
+    ) -> StorageResult<Self> {
+        let storage_server_endpoint = storage_server_endpoint_str.parse::<Uri>().map_err(|_| {
+            DataFusionError::Configuration(format!(
+                "cannot connect to the storage server with uri {}",
+                storage_server_endpoint_str
+            ))
+        })?;
+        let catalog_server_endpoint = catalog_server_endpoint_str.parse::<Uri>().map_err(|_| {
+            DataFusionError::Configuration(format!(
+                "cannot connect to the catalog server with uri {}",
+                catalog_server_endpoint_str
+            ))
+        })?;
+        Ok(Self {
+            _storage_server_endpoint: storage_server_endpoint,
+            _catalog_server_endpoint: catalog_server_endpoint,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl StorageClient for StorageClientImpl {
+    async fn request_data(
+        &self,
+        _request: StorageRequest,
+    ) -> StorageResult<SendableRecordBatchStream> {
+        todo!()
+    }
+
+    async fn request_data_sync(&self, _request: StorageRequest) -> StorageResult<Vec<RecordBatch>> {
+        todo!()
+    }
+}

--- a/storage-client/src/client.rs
+++ b/storage-client/src/client.rs
@@ -16,13 +16,13 @@ impl StorageClientImpl {
     ) -> StorageResult<Self> {
         let storage_server_endpoint = storage_server_endpoint_str.parse::<Uri>().map_err(|_| {
             DataFusionError::Configuration(format!(
-                "cannot connect to the storage server with uri {}",
+                "cannot resolve storage server endpoint: {}",
                 storage_server_endpoint_str
             ))
         })?;
         let catalog_server_endpoint = catalog_server_endpoint_str.parse::<Uri>().map_err(|_| {
             DataFusionError::Configuration(format!(
-                "cannot connect to the catalog server with uri {}",
+                "cannot resolve catalog server endpoint: {}",
                 catalog_server_endpoint_str
             ))
         })?;

--- a/storage-client/src/client.rs
+++ b/storage-client/src/client.rs
@@ -1,8 +1,9 @@
+use anyhow::{anyhow, Result};
 use arrow::record_batch::RecordBatch;
-use datafusion::{error::DataFusionError, physical_plan::SendableRecordBatchStream};
 use hyper::Uri;
+use tokio::sync::mpsc::Receiver;
 
-use crate::{StorageClient, StorageRequest, StorageResult};
+use crate::{StorageClient, StorageRequest};
 
 pub struct StorageClientImpl {
     _storage_server_endpoint: Uri,
@@ -13,18 +14,18 @@ impl StorageClientImpl {
     pub fn new(
         storage_server_endpoint_str: &str,
         catalog_server_endpoint_str: &str,
-    ) -> StorageResult<Self> {
+    ) -> Result<Self> {
         let storage_server_endpoint = storage_server_endpoint_str.parse::<Uri>().map_err(|_| {
-            DataFusionError::Configuration(format!(
+            anyhow!(
                 "cannot resolve storage server endpoint: {}",
                 storage_server_endpoint_str
-            ))
+            )
         })?;
         let catalog_server_endpoint = catalog_server_endpoint_str.parse::<Uri>().map_err(|_| {
-            DataFusionError::Configuration(format!(
+            anyhow!(
                 "cannot resolve catalog server endpoint: {}",
                 catalog_server_endpoint_str
-            ))
+            )
         })?;
         Ok(Self {
             _storage_server_endpoint: storage_server_endpoint,
@@ -35,14 +36,11 @@ impl StorageClientImpl {
 
 #[async_trait::async_trait]
 impl StorageClient for StorageClientImpl {
-    async fn request_data(
-        &self,
-        _request: StorageRequest,
-    ) -> StorageResult<SendableRecordBatchStream> {
+    async fn request_data(&self, _request: StorageRequest) -> Result<Receiver<RecordBatch>> {
         todo!()
     }
 
-    async fn request_data_sync(&self, _request: StorageRequest) -> StorageResult<Vec<RecordBatch>> {
+    async fn request_data_sync(&self, _request: StorageRequest) -> Result<Vec<RecordBatch>> {
         todo!()
     }
 }

--- a/storage-client/src/lib.rs
+++ b/storage-client/src/lib.rs
@@ -4,34 +4,34 @@ use arrow::record_batch::RecordBatch;
 use datafusion::{error::DataFusionError, physical_plan::SendableRecordBatchStream};
 
 /// Result type that the storage node would return to the execution engine. We use
-/// `DataFusionError` here to align with the execution engin.
+/// `DataFusionError` here to align with the execution engine.
 pub type StorageResult<T> = anyhow::Result<T, DataFusionError>;
 
-/// Types for table id and column id. Need to be consistent among all components
+/// Id types for table, column, and record. Need to be consistent among all components
 /// (e.g. execution engine). We don't want to make any type generic here just for the id,
 /// so we simply define them here. Might refine later.
 pub type TableId = u64;
 pub type ColumnId = u64;
 pub type RecordId = u64;
 
-/// [`StorageRequestType`] specifies the types of the requests that the execution engine
-/// might issue to the storage node.
+/// [`StorageRequest`] specifies the requests that the execution engine might issue to
+/// the storage node.
 ///
 /// Currently we assume the execution engine only requests the whole table/column. We may
 /// add `std::ops::RangeBounds` later to support range query from the execution engine.
 pub enum StorageRequest {
-    /// Request a whole table from the underlying storage.
+    /// Requests a whole table from the underlying storage.
     Table(TableId),
-    /// Request one or more columns from the underlying storage.
+    /// Requests one or more columns from the underlying storage.
     Columns(TableId, Vec<ColumnId>),
-    /// Request one or more tuples from the underlying storage.
+    /// Requests one or more tuples from the underlying storage.
     /// FIXME: Do we really need this?
     Tuple(Vec<RecordId>),
 }
 
 /// [`StorageClient`] provides the interface for the execution engine to query data from the
-/// storage node. It resolves the physical location of the tables/columns by querying the
-/// catalog node, and then sends the request to the storage node to get the data from the
+/// storage node. It resolves the physical location of the tables/columns/tuples by querying
+/// the catalog node, and then sends the request to the storage node to get the data from the
 /// underlying storage.
 #[async_trait::async_trait]
 pub trait StorageClient: Send + Sync + 'static {

--- a/storage-client/src/lib.rs
+++ b/storage-client/src/lib.rs
@@ -1,0 +1,48 @@
+pub mod client;
+
+use arrow::record_batch::RecordBatch;
+use datafusion::{error::DataFusionError, physical_plan::SendableRecordBatchStream};
+
+/// Result type that the storage node would return to the execution engine. We use
+/// `DataFusionError` here to align with the execution engin.
+pub type StorageResult<T> = anyhow::Result<T, DataFusionError>;
+
+/// Types for table id and column id. Need to be consistent among all components
+/// (e.g. execution engine). We don't want to make any type generic here just for the id,
+/// so we simply define them here. Might refine later.
+pub type TableId = u64;
+pub type ColumnId = u64;
+pub type RecordId = u64;
+
+/// [`StorageRequestType`] specifies the types of the requests that the execution engine
+/// might issue to the storage node.
+///
+/// Currently we assume the execution engine only requests the whole table/column. We may
+/// add `std::ops::RangeBounds` later to support range query from the execution engine.
+pub enum StorageRequest {
+    /// Request a whole table from the underlying storage.
+    Table(TableId),
+    /// Request one or more columns from the underlying storage.
+    Columns(TableId, Vec<ColumnId>),
+    /// Request one or more tuples from the underlying storage.
+    /// FIXME: Do we really need this?
+    Tuple(Vec<RecordId>),
+}
+
+/// [`StorageClient`] provides the interface for the execution engine to query data from the
+/// storage node. It resolves the physical location of the tables/columns by querying the
+/// catalog node, and then sends the request to the storage node to get the data from the
+/// underlying storage.
+#[async_trait::async_trait]
+pub trait StorageClient: Send + Sync + 'static {
+    /// Returns the requested data as a stream.
+    ///
+    /// FIXME: Should we use `StorageResult<mpsc::Receiver<RecordBatch>>` instead?
+    async fn request_data(
+        &self,
+        request: StorageRequest,
+    ) -> StorageResult<SendableRecordBatchStream>;
+
+    /// Returns all the requested data as a whole.
+    async fn request_data_sync(&self, request: StorageRequest) -> StorageResult<Vec<RecordBatch>>;
+}


### PR DESCRIPTION
We provide a trait of `StorageClient` for the execution engine, instead of a concrete struct type. It should function very much alike [the one @Connortsui20 prototypes](https://github.com/cmu-db/15721-s24-ee1/blob/fa9e3fb85bbff53545d50195650b483b54a1d1e8/eggstrain/src/storage_client/mod.rs) before. In this way we can decouple the implementation and the interface of the storage client. Also, this should provide the execution engine teams with more flexibility (e.g. implement their own `MockStorageClient` for testing).

I/O service should implement this trait for their own storage client, which the execution engine may wish to call for querying storage data. This PR provides an example implementation of the `StorageClient` (see `StorageClientImpl`) though the request data part is not implemented...