### PR TITLE
refactor: enable storage client to support S3 requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       run: cargo clippy --all-targets --all-features
     - name: Compile check
       run: cargo check --all-targets --all-features
-    - name: Run tests & Generate code coverage
+    - name: Run tests and Generate code coverage
       run: cargo llvm-cov --all-features --workspace --codecov --output-path lcov.info
     - name: Archive code coverage results
       uses: actions/upload-artifact@v4

--- a/storage-client/src/client.rs
+++ b/storage-client/src/client.rs
@@ -4,7 +4,7 @@ use futures::stream::StreamExt;
 use futures::TryStreamExt;
 use hyper::Uri;
 use parquet::arrow::{ParquetRecordBatchStreamBuilder, ProjectionMask};
-use reqwest::Client;
+use reqwest::{Client, Url};
 use std::fs::File;
 use std::io::Write;
 use storage_common::RequestParams;
@@ -50,7 +50,9 @@ impl StorageClientImpl {
     async fn get_info_from_catalog(&self, _request: StorageRequest) -> Result<RequestParams> {
         // FIXME (kunle): Need to discuss with the catalog team.
         // The following line serves as a placeholder for now.
-        Ok(RequestParams::File("userdata1.parquet".to_string()))
+        let bucket = "tests-parquet".to_string();
+        let keys = vec!["userdata1.parquet".to_string()];
+        Ok(RequestParams::S3((bucket, keys)))
     }
 }
 
@@ -59,7 +61,7 @@ impl StorageClient for StorageClientImpl {
     async fn request_data(&self, _request: StorageRequest) -> Result<Receiver<RecordBatch>> {
         // First we need to get the location of the parquet file from the catalog server.
         let _location = match self.get_info_from_catalog(_request).await? {
-            RequestParams::File(location) => location,
+            RequestParams::S3(location) => location,
             _ => {
                 return Err(anyhow!(
                     "Failed to get location of the file from the catalog server."
@@ -68,9 +70,10 @@ impl StorageClient for StorageClientImpl {
         };
 
         // Then we need to send the request to the storage server.
-        let url = format!("{}file/{}", self._storage_server_endpoint, _location);
         let client = Client::new();
-        println!("Requesting data from: {}", url);
+        let url = format!("{}file", self._storage_server_endpoint);
+        let params = [("bucket", _location.0), ("keys", _location.1.join(","))];
+        let url = Url::parse_with_params(&url, params)?;
         let response = client.get(url).send().await?;
         if response.status().is_success() {
             // Store the streamed Parquet file in a temporary file.
@@ -131,7 +134,7 @@ mod tests {
         let mut server = Server::new_async().await;
         println!("server host: {}", server.host_with_port());
         server
-            .mock("GET", "/file/userdata1.parquet")
+            .mock("GET", "/file?bucket=tests-parquet&keys=userdata1.parquet")
             .with_body_from_file("../storage-node/tests/parquet/userdata1.parquet")
             .create_async()
             .await;

--- a/storage-client/src/client.rs
+++ b/storage-client/src/client.rs
@@ -60,7 +60,7 @@ impl StorageClientImpl {
 impl StorageClient for StorageClientImpl {
     async fn request_data(&self, _request: StorageRequest) -> Result<Receiver<RecordBatch>> {
         // First we need to get the location of the parquet file from the catalog server.
-        let _location = match self.get_info_from_catalog(_request).await? {
+        let location = match self.get_info_from_catalog(_request).await? {
             RequestParams::S3(location) => location,
             _ => {
                 return Err(anyhow!(
@@ -72,7 +72,7 @@ impl StorageClient for StorageClientImpl {
         // Then we need to send the request to the storage server.
         let client = Client::new();
         let url = format!("{}file", self._storage_server_endpoint);
-        let params = [("bucket", _location.0), ("keys", _location.1.join(","))];
+        let params = [("bucket", location.0), ("keys", location.1.join(","))];
         let url = Url::parse_with_params(&url, params)?;
         let response = client.get(url).send().await?;
         if response.status().is_success() {

--- a/storage-common/Cargo.toml
+++ b/storage-common/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 enum-as-inner = "0.6.0"
+serde = { version = "1.0", features = ["derive"] }

--- a/storage-common/src/lib.rs
+++ b/storage-common/src/lib.rs
@@ -11,6 +11,6 @@ pub enum RequestParams {
 #[derive(Deserialize)]
 pub struct S3Request {
     pub bucket: String,
-    /// Cannot serialize a vector of strings, might need to customize a deserializer later.
+    /// Cannot deserialize a vector of strings, might need to customize a deserializer later.
     pub keys: String,
 }

--- a/storage-common/src/lib.rs
+++ b/storage-common/src/lib.rs
@@ -1,8 +1,16 @@
 use enum_as_inner::EnumAsInner;
+use serde::Deserialize;
 
 #[derive(Clone, EnumAsInner, Debug)]
 pub enum RequestParams {
     File(String),
     /// S3 bucket and keys.
     S3((String, Vec<String>)),
+}
+
+#[derive(Deserialize)]
+pub struct S3Request {
+    pub bucket: String,
+    /// Cannot serialize a vector of strings, might need to customize a deserializer later.
+    pub keys: String,
 }

--- a/storage-node/src/server.rs
+++ b/storage-node/src/server.rs
@@ -1,6 +1,6 @@
 use futures::lock::Mutex;
 use std::sync::Arc;
-use storage_common::RequestParams;
+use storage_common::{RequestParams, S3Request};
 use tokio_stream::wrappers::ReceiverStream;
 use warp::{Filter, Rejection};
 
@@ -23,15 +23,19 @@ pub async fn storage_node_serve() -> ParpulseResult<()> {
     // TODO: try to use more fine-grained lock instead of locking the whole storage_manager
     let storage_manager = Arc::new(Mutex::new(StorageManager::new(data_store_cache)));
 
-    let route = warp::path!("file" / String)
+    let route = warp::path!("file")
         .and(warp::path::end())
-        .and_then(move |file_name: String| {
+        .and(warp::query::<S3Request>())
+        .and_then(move |params: S3Request| {
             let storage_manager = storage_manager.clone();
+            println!(
+                "Received request for bucket: {}, keys: {:?}",
+                params.bucket, params.keys
+            );
             async move {
-                println!("File Name: {}", file_name);
-                let bucket = "tests-parquet".to_string();
-                let keys = vec![file_name];
-                let request = RequestParams::S3((bucket, keys));
+                let bucket = params.bucket;
+                let keys = params.keys;
+                let request = RequestParams::S3((bucket, vec![keys]));
                 let result = storage_manager.lock().await.get_data(request).await;
                 let data_rx = result.unwrap();
 
@@ -48,7 +52,16 @@ pub async fn storage_node_serve() -> ParpulseResult<()> {
             }
         });
 
-    warp::serve(route).run(([127, 0, 0, 1], 3030)).await;
+    // Catch a request that does not match any of the routes above.
+    let catch_all = warp::any()
+        .and(warp::path::full())
+        .map(|path: warp::path::FullPath| {
+            println!("Catch all route hit. Path: {}", path.as_str());
+            warp::http::StatusCode::NOT_FOUND
+        });
+
+    let routes = route.or(catch_all);
+    warp::serve(routes).run(([127, 0, 0, 1], 3030)).await;
 
     Ok(())
 }
@@ -74,7 +87,7 @@ mod tests {
         // Give the server some time to start
         tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
-        let url = "http://localhost:3030/file/userdata1.parquet";
+        let url = "http://localhost:3030/file?bucket=tests-parquet&keys=userdata1.parquet";
         let client = Client::new();
         let mut response = client
             .get(url)


### PR DESCRIPTION
Support handling all bucket + single key S3 requests in both client and server.

Previously, all file paths are hard-coded in the data retrieval functions themselves. They are now configured outside these functions so that S3 requests are not limited to a single file anymore.