### PR TITLE
chore: add trace generator and replace catalog with hashmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ Cargo.lock
 
 data/
 
+**/*.pem
+

--- a/scripts/decode_parquet.py
+++ b/scripts/decode_parquet.py
@@ -3,7 +3,7 @@ This file is used to decode a parquet file and display the first n rows of the
 file, mainly for visualization purposes.
 
 Usage:
-    python decode_parquet.py <path-to-parquet-file> --n
+    python scripts/decode_parquet.py <path-to-parquet-file> --n
     <number-of-rows-to-display>
 """
 

--- a/scripts/generate_traces.py
+++ b/scripts/generate_traces.py
@@ -1,3 +1,10 @@
+"""
+This script generates access pattern for a set of files with a Zipfian distribution.
+
+Usage:
+    python scripts/generate_traces.py --num_files 10 --skew_param 1.2 --num_accesses 100 -o <YOUR_OUTPUT_FILE>
+"""
+
 import numpy as np
 import csv
 import argparse

--- a/scripts/generate_traces.py
+++ b/scripts/generate_traces.py
@@ -1,0 +1,66 @@
+import numpy as np
+import csv
+import argparse
+import random
+
+
+def generate_access_counts(num_files, s, num_accesses):
+    access_counts = [0] * num_files
+    # Generate Zipfian distribution probabilities
+    probabilities = 1 / np.arange(1, num_files + 1) ** s
+    # Normalize
+    probabilities /= np.sum(probabilities)
+
+    # Simulate file accesses
+    for _ in range(num_accesses):
+        file_index = np.random.choice(np.arange(num_files), p=probabilities)
+        access_counts[file_index] += 1
+
+    return access_counts
+
+
+def write_to_csv(access_counts, output_file):
+    with open(output_file, "w") as f:
+        writer = csv.writer(f)
+        timestamp = 0  # timestamp is in milliseconds
+        for i, count in enumerate(access_counts):
+            # timestamp, filename, access_count
+            writer.writerow(
+                [timestamp, f"random_data_100m_{i}.parquet", count])
+            timestamp += random.randint(1, 500)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Generate access counts with a Zipfian distribution")
+    parser.add_argument(
+        "-nf",
+        "--num_files",
+        type=int,
+        default=10,
+        help="Number of files (default: 10)")
+    parser.add_argument(
+        "-s",
+        "--skew_param",
+        type=float,
+        default=1.2,
+        help="Skew parameter (default: 1.2)")
+    parser.add_argument(
+        "-na",
+        "--num_accesses",
+        type=int,
+        default=100,
+        help="Number of accesses (default: 100)")
+    parser.add_argument(
+        "-o",
+        "--output_file",
+        type=str,
+        default="data/trace_100m.csv",
+        help="Output CSV file (default: data/trace.csv)")
+    args = parser.parse_args()
+
+    access_counts = generate_access_counts(
+        args.num_files, args.skew_param, args.num_accesses)
+    write_to_csv(access_counts, args.output_file)
+
+    print("Access counts generated and written to", args.output_file)

--- a/scripts/generate_traces.py
+++ b/scripts/generate_traces.py
@@ -10,9 +10,12 @@ import csv
 import argparse
 import random
 
+mp = {1: [1, 2, 3, 4, 5, 6, 7, 8, 9], 100: [
+    10, 11, 12, 13, 14, 15, 16, 17, 18, 19]}
 
-def generate_access_counts(num_files, s, num_accesses):
-    access_counts = [0] * num_files
+
+def generate_access_counts(num_files, s, num_accesses, file_size):
+    access_counts = []
     # Generate Zipfian distribution probabilities
     probabilities = 1 / np.arange(1, num_files + 1) ** s
     # Normalize
@@ -20,8 +23,8 @@ def generate_access_counts(num_files, s, num_accesses):
 
     # Simulate file accesses
     for _ in range(num_accesses):
-        file_index = np.random.choice(np.arange(num_files), p=probabilities)
-        access_counts[file_index] += 1
+        file_index = np.random.choice(mp[file_size], p=probabilities)
+        access_counts.append(file_index)
 
     return access_counts
 
@@ -30,10 +33,8 @@ def write_to_csv(access_counts, output_file):
     with open(output_file, "w") as f:
         writer = csv.writer(f)
         timestamp = 0  # timestamp is in milliseconds
-        for i, count in enumerate(access_counts):
-            # timestamp, filename, access_count
-            writer.writerow(
-                [timestamp, f"random_data_100m_{i}.parquet", count])
+        for file_index in access_counts:
+            writer.writerow([timestamp, file_index])
             timestamp += random.randint(1, 500)
 
 
@@ -41,7 +42,6 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(
         description="Generate access counts with a Zipfian distribution")
     parser.add_argument(
-        "-nf",
         "--num_files",
         type=int,
         default=10,
@@ -50,24 +50,32 @@ if __name__ == "__main__":
         "-s",
         "--skew_param",
         type=float,
-        default=1.2,
-        help="Skew parameter (default: 1.2)")
+        default=1.5,
+        help="Skew parameter (default: 1.5)")
     parser.add_argument(
-        "-na",
         "--num_accesses",
         type=int,
-        default=100,
-        help="Number of accesses (default: 100)")
+        default=20,
+        help="Number of accesses (default: 20)")
     parser.add_argument(
         "-o",
         "--output_file",
         type=str,
-        default="data/trace_100m.csv",
+        default="data/traces/trace_1m.csv",
         help="Output CSV file (default: data/trace.csv)")
+    parser.add_argument(
+        "--size",
+        type=int,
+        default=1,
+        help="Size of the parquet file in MB"
+    )
     args = parser.parse_args()
 
+    if args.size not in mp:
+        raise ValueError("Size should be either 1 or 100")
+
     access_counts = generate_access_counts(
-        args.num_files, args.skew_param, args.num_accesses)
+        args.num_files, args.skew_param, args.num_accesses, args.size)
     write_to_csv(access_counts, args.output_file)
 
     print("Access counts generated and written to", args.output_file)

--- a/storage-client/Cargo.toml
+++ b/storage-client/Cargo.toml
@@ -8,7 +8,7 @@ arrow-array = "51.0.0"
 anyhow = "1"
 hyper = "1"
 async-trait = "0.1"
-tokio = { version = "1", features = ["sync"] }
+tokio = { version = "1", features = ["full", "rt-multi-thread"] }
 storage-common = { path = "../storage-common" }
 futures = "0.3"
 reqwest = { version = "0.12", features = ["stream"] }

--- a/storage-client/Cargo.toml
+++ b/storage-client/Cargo.toml
@@ -17,3 +17,4 @@ parquet = { version = "51.0.0", features = ["async"] }
 arrow = "51.0.0"
 mockito = "1.4.0"
 log = "0.4"
+lazy_static = "1.4"

--- a/storage-client/src/bin/driver.rs
+++ b/storage-client/src/bin/driver.rs
@@ -1,0 +1,50 @@
+use arrow_array::Float64Array;
+use log::info;
+use std::time::Instant;
+use storage_client::{client::StorageClientImpl, StorageClient, StorageRequest};
+use storage_common::init_logger;
+
+/// This test is for benchmarking.
+
+#[tokio::main]
+async fn main() {
+    init_logger();
+    let storage_client =
+        StorageClientImpl::new("http://44.220.220.131:8000", "http://127.0.0.1:3031")
+            .expect("Failed to create storage client.");
+    let start_time = Instant::now();
+    // Requesting random_data_100m_0.parquet
+    let request = StorageRequest::Table(10);
+    let mut receiver = storage_client
+        .request_data(request)
+        .await
+        .expect("Failed to get data from the server.");
+    let mut record_batches = vec![];
+    while let Some(record_batch) = receiver.recv().await {
+        record_batches.push(record_batch);
+    }
+    info!("Time taken for 100m file: {:?}", start_time.elapsed());
+
+    assert!(!record_batches.is_empty());
+
+    let first_batch = &record_batches[0];
+    assert_eq!(first_batch.num_columns(), 20);
+
+    // Check the first 5 columns of the first row.
+    let real_first_row = [
+        0.869278151694903,
+        0.5698583744743971,
+        0.5731127546817466,
+        0.9509491985107434,
+        0.3949108352357301,
+    ];
+    for (i, &real_value) in real_first_row.iter().enumerate() {
+        let column = first_batch
+            .column(i)
+            .as_any()
+            .downcast_ref::<Float64Array>()
+            .unwrap();
+        assert_eq!(column.value(0), real_value);
+    }
+    info!("Succeed!")
+}

--- a/storage-client/src/client.rs
+++ b/storage-client/src/client.rs
@@ -18,7 +18,7 @@ use crate::{StorageClient, StorageRequest, TableId};
 
 /// The batch size for the record batch.
 const BATCH_SIZE: usize = 100;
-const CHANNEL_CAPACITY: usize = 10;
+const CHANNEL_CAPACITY: usize = 32;
 const PARAM_BUCKET_KEY: &str = "bucket";
 const PARAM_KEYS_KEY: &str = "keys";
 
@@ -28,25 +28,12 @@ lazy_static! {
         // For mock s3
         m.insert(0, "userdata1.parquet".to_string());
         // All the remainings are for real s3
-        m.insert(1, "1m/random_data_1m_1.parquet".to_string());
-        m.insert(2, "1m/random_data_1m_2.parquet".to_string());
-        m.insert(3, "1m/random_data_1m_3.parquet".to_string());
-        m.insert(4, "1m/random_data_1m_4.parquet".to_string());
-        m.insert(5, "1m/random_data_1m_5.parquet".to_string());
-        m.insert(6, "1m/random_data_1m_6.parquet".to_string());
-        m.insert(7, "1m/random_data_1m_7.parquet".to_string());
-        m.insert(8, "1m/random_data_1m_8.parquet".to_string());
-        m.insert(9, "1m/random_data_1m_9.parquet".to_string());
-        m.insert(10, "100m/random_data_100m_0.parquet".to_string());
-        m.insert(11, "100m/random_data_100m_1.parquet".to_string());
-        m.insert(12, "100m/random_data_100m_2.parquet".to_string());
-        m.insert(13, "100m/random_data_100m_3.parquet".to_string());
-        m.insert(14, "100m/random_data_100m_4.parquet".to_string());
-        m.insert(15, "100m/random_data_100m_5.parquet".to_string());
-        m.insert(16, "100m/random_data_100m_6.parquet".to_string());
-        m.insert(17, "100m/random_data_100m_7.parquet".to_string());
-        m.insert(18, "100m/random_data_100m_8.parquet".to_string());
-        m.insert(19, "100m/random_data_100m_9.parquet".to_string());
+        for i in 1..=9 {
+            m.insert(i, format!("1m/random_data_1m_{}.parquet", i));
+        }
+        for i in 10..=19 {
+            m.insert(i, format!("100m/random_data_100m_{}.parquet", i - 9));
+        }
         m
     };
 }

--- a/storage-client/src/client.rs
+++ b/storage-client/src/client.rs
@@ -114,8 +114,12 @@ impl StorageClientImpl {
             Ok(rx)
         } else {
             Err(anyhow::anyhow!(
-                "Failed to download file. Response: {:?}",
-                response.status()
+                "Failed to download file. Response: {:?}, Body: {}",
+                response.status(),
+                response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| String::from("Failed to read response body"))
             ))
         }
     }

--- a/storage-client/src/client.rs
+++ b/storage-client/src/client.rs
@@ -32,7 +32,7 @@ lazy_static! {
             m.insert(i, format!("1m/random_data_1m_{}.parquet", i));
         }
         for i in 10..=19 {
-            m.insert(i, format!("100m/random_data_100m_{}.parquet", i - 9));
+            m.insert(i, format!("100m/random_data_100m_{}.parquet", i - 10));
         }
         m
     };

--- a/storage-client/src/client.rs
+++ b/storage-client/src/client.rs
@@ -3,8 +3,10 @@ use arrow_array::RecordBatch;
 use futures::stream::StreamExt;
 use futures::TryStreamExt;
 use hyper::Uri;
+use lazy_static::lazy_static;
 use parquet::arrow::{ParquetRecordBatchStreamBuilder, ProjectionMask};
 use reqwest::{Client, Response, Url};
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
 use storage_common::RequestParams;
@@ -12,13 +14,42 @@ use tempfile::tempdir;
 use tokio::fs::File as AsyncFile;
 use tokio::sync::mpsc::{channel, Receiver};
 
-use crate::{StorageClient, StorageRequest};
+use crate::{StorageClient, StorageRequest, TableId};
 
 /// The batch size for the record batch.
-const BATCH_SIZE: usize = 3;
+const BATCH_SIZE: usize = 100;
 const CHANNEL_CAPACITY: usize = 10;
 const PARAM_BUCKET_KEY: &str = "bucket";
 const PARAM_KEYS_KEY: &str = "keys";
+
+lazy_static! {
+    static ref TABLE_FILE_MAP: HashMap<TableId, String> = {
+        let mut m = HashMap::new();
+        // For mock s3
+        m.insert(0, "userdata1.parquet".to_string());
+        // All the remainings are for real s3
+        m.insert(1, "1m/random_data_1m_1.parquet".to_string());
+        m.insert(2, "1m/random_data_1m_2.parquet".to_string());
+        m.insert(3, "1m/random_data_1m_3.parquet".to_string());
+        m.insert(4, "1m/random_data_1m_4.parquet".to_string());
+        m.insert(5, "1m/random_data_1m_5.parquet".to_string());
+        m.insert(6, "1m/random_data_1m_6.parquet".to_string());
+        m.insert(7, "1m/random_data_1m_7.parquet".to_string());
+        m.insert(8, "1m/random_data_1m_8.parquet".to_string());
+        m.insert(9, "1m/random_data_1m_9.parquet".to_string());
+        m.insert(10, "100m/random_data_100m_0.parquet".to_string());
+        m.insert(11, "100m/random_data_100m_1.parquet".to_string());
+        m.insert(12, "100m/random_data_100m_2.parquet".to_string());
+        m.insert(13, "100m/random_data_100m_3.parquet".to_string());
+        m.insert(14, "100m/random_data_100m_4.parquet".to_string());
+        m.insert(15, "100m/random_data_100m_5.parquet".to_string());
+        m.insert(16, "100m/random_data_100m_6.parquet".to_string());
+        m.insert(17, "100m/random_data_100m_7.parquet".to_string());
+        m.insert(18, "100m/random_data_100m_8.parquet".to_string());
+        m.insert(19, "100m/random_data_100m_9.parquet".to_string());
+        m
+    };
+}
 
 pub struct StorageClientImpl {
     storage_server_endpoint: Uri,
@@ -49,11 +80,15 @@ impl StorageClientImpl {
     }
 
     /// Returns the physical location of the requested data in RequestParams.
-    async fn get_info_from_catalog(&self, _request: StorageRequest) -> Result<RequestParams> {
-        // FIXME (kunle): Need to discuss with the catalog team.
-        // The following line serves as a placeholder for now.
+    async fn get_info_from_catalog(&self, request: StorageRequest) -> Result<RequestParams> {
         let bucket = "parpulse-test".to_string();
-        let keys = vec!["userdata/userdata1.parquet".to_string()];
+        let table_id = match request {
+            StorageRequest::Table(id) => id,
+            _ => {
+                return Err(anyhow!("Only table request is supported."));
+            }
+        };
+        let keys = vec![TABLE_FILE_MAP.get(&table_id).unwrap().to_string()];
         Ok(RequestParams::S3((bucket, keys)))
     }
 
@@ -98,9 +133,15 @@ impl StorageClientImpl {
         }
     }
 
-    async fn get_info_from_catalog_test(&self, _request: StorageRequest) -> Result<RequestParams> {
+    async fn get_info_from_catalog_test(&self, request: StorageRequest) -> Result<RequestParams> {
         let bucket = "tests-parquet".to_string();
-        let keys = vec!["userdata1.parquet".to_string()];
+        let table_id = match request {
+            StorageRequest::Table(id) => id,
+            _ => {
+                return Err(anyhow!("Only table request is supported."));
+            }
+        };
+        let keys = vec![TABLE_FILE_MAP.get(&table_id).unwrap().to_string()];
         Ok(RequestParams::MockS3((bucket, keys)))
     }
 
@@ -137,6 +178,7 @@ impl StorageClientImpl {
 
         let url = Url::parse_with_params(&url, params)?;
         let response = client.get(url).send().await?;
+
         Self::get_data_from_response(response).await
     }
 }
@@ -176,7 +218,7 @@ mod tests {
 
     /// WARNING: Put userdata1.parquet in the storage-node/tests/parquet directory before running this test.
     #[tokio::test]
-    async fn test_storage_client_wo_ee_catalog() {
+    async fn test_storage_client_disk() {
         // Create a mock server to serve the parquet file.
         let mut server = Server::new_async().await;
         println!("server host: {}", server.host_with_port());
@@ -190,10 +232,10 @@ mod tests {
             .await;
 
         let server_endpoint = server.url() + "/";
-        // The catalog endpoint is not used anyway. So randomly pass a url.
         let storage_client = StorageClientImpl::new(&server_endpoint, "localhost:3031")
             .expect("Failed to create storage client.");
-        let request = StorageRequest::Table(1);
+        // 0 is the table id for userdata1.parquet on local disk.
+        let request = StorageRequest::Table(0);
         let mut receiver = storage_client
             .request_data_test(request)
             .await
@@ -207,15 +249,22 @@ mod tests {
         let first_batch = &record_batches[0];
         assert_eq!(first_batch.num_columns(), 13);
 
-        let first_names = StringArray::from(vec!["Amanda", "Albert", "Evelyn"]);
-        let last_names = StringArray::from(vec!["Jordan", "Freeman", "Morgan"]);
-        assert_eq!(
-            first_batch.column(2).as_any().downcast_ref::<StringArray>(),
-            Some(&first_names)
-        );
-        assert_eq!(
-            first_batch.column(3).as_any().downcast_ref::<StringArray>(),
-            Some(&last_names)
-        );
+        let real_first_names = StringArray::from(vec!["Amanda", "Albert", "Evelyn"]);
+        let read_last_names = StringArray::from(vec!["Jordan", "Freeman", "Morgan"]);
+        let first_names = first_batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let last_names = first_batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        // Check the first three entries in the first and last name columns.
+        for i in 0..3 {
+            assert_eq!(first_names.value(i), real_first_names.value(i));
+            assert_eq!(last_names.value(i), read_last_names.value(i));
+        }
     }
 }

--- a/storage-node/src/bin/storage_node.rs
+++ b/storage-node/src/bin/storage_node.rs
@@ -9,5 +9,7 @@ async fn main() {
         .filter_level(log::LevelFilter::Info)
         .try_init();
     info!("starting storage node server...");
-    storage_node_serve().await.unwrap();
+    storage_node_serve(&"0.0.0.0".to_string(), 80)
+        .await
+        .unwrap();
 }

--- a/storage-node/src/bin/storage_node.rs
+++ b/storage-node/src/bin/storage_node.rs
@@ -9,7 +9,5 @@ async fn main() {
         .filter_level(log::LevelFilter::Info)
         .try_init();
     info!("starting storage node server...");
-    storage_node_serve(&"0.0.0.0".to_string(), 80)
-        .await
-        .unwrap();
+    storage_node_serve("0.0.0.0", 80).await.unwrap();
 }

--- a/storage-node/src/server.rs
+++ b/storage-node/src/server.rs
@@ -49,7 +49,11 @@ pub async fn storage_node_serve(ip_addr: &str, port: u16) -> ParpulseResult<()> 
                 } else {
                     RequestParams::S3((bucket, vec![keys]))
                 };
-                let result = storage_manager.lock().await.get_data(request).await;
+                let result = storage_manager
+                    .lock()
+                    .await
+                    .get_data(request, is_mem_disk_cache)
+                    .await;
                 match result {
                     Ok(data_rx) => {
                         let stream = ReceiverStream::new(data_rx);

--- a/storage-node/src/server.rs
+++ b/storage-node/src/server.rs
@@ -14,7 +14,8 @@ use crate::{
 const CACHE_BASE_PATH: &str = "cache/";
 
 pub async fn storage_node_serve() -> ParpulseResult<()> {
-    let dummy_size = 1000000;
+    // Should at least be able to store one 100MB file in the cache.
+    let dummy_size = 100 * 1024 * 1024;
     // TODO: Read the type of the cache from config.
     let cache = LruReplacer::new(dummy_size);
     // TODO: cache_base_path should be from config

--- a/storage-node/src/server.rs
+++ b/storage-node/src/server.rs
@@ -145,4 +145,31 @@ mod tests {
 
         server_handle.abort();
     }
+
+    #[tokio::test]
+    async fn test_file_not_exist() {
+        // Start the server
+        let server_handle = tokio::spawn(async move {
+            storage_node_serve("127.0.0.1", 3030).await.unwrap();
+        });
+
+        // Give the server some time to start
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+        let url =
+            "http://localhost:3030/file?bucket=tests-parquet&keys=not_exist.parquet&is_test=true";
+        let client = Client::new();
+        let response = client
+            .get(url)
+            .send()
+            .await
+            .expect("Failed to get response from the server.");
+
+        assert!(
+            response.status().is_server_error(),
+            "Expected 500 status code"
+        );
+
+        server_handle.abort();
+    }
 }

--- a/storage-node/src/server.rs
+++ b/storage-node/src/server.rs
@@ -14,7 +14,7 @@ use crate::{
 
 const CACHE_BASE_PATH: &str = "cache/";
 
-pub async fn storage_node_serve(ip_addr: &String, port: u16) -> ParpulseResult<()> {
+pub async fn storage_node_serve(ip_addr: &str, port: u16) -> ParpulseResult<()> {
     // Should at least be able to store one 100MB file in the cache.
     let dummy_size = 100 * 1024 * 1024;
     // TODO: Read the type of the cache from config.
@@ -107,9 +107,7 @@ mod tests {
 
         // Start the server
         let server_handle = tokio::spawn(async move {
-            storage_node_serve(&"127.0.0.1".to_string(), 3030)
-                .await
-                .unwrap();
+            storage_node_serve("127.0.0.1", 3030).await.unwrap();
         });
 
         // Give the server some time to start

--- a/storage-node/src/storage_reader/s3_diskmock.rs
+++ b/storage-node/src/storage_reader/s3_diskmock.rs
@@ -17,7 +17,7 @@ use crate::{
 
 use super::{AsyncStorageReader, StorageReaderStream};
 
-const DELAY: Option<Duration> = Some(Duration::from_millis(100));
+const DELAY: Option<Duration> = Some(Duration::from_millis(1));
 const MIN_DISK_READ_SIZE: usize = 1024 * 512;
 const MAX_DISK_READ_SIZE: usize = 1024 * 1024;
 

--- a/tests/src/client_server_test.rs
+++ b/tests/src/client_server_test.rs
@@ -35,6 +35,7 @@ mod tests {
         let storage_client =
             StorageClientImpl::new("http://127.0.0.1:3030", "http://127.0.0.1:3031")
                 .expect("Failed to create storage client.");
+        let start_time = Instant::now();
         let request = StorageRequest::Table(0);
         let mut receiver = storage_client
             .request_data_test(request)
@@ -44,6 +45,10 @@ mod tests {
         while let Some(record_batch) = receiver.recv().await {
             record_batches.push(record_batch);
         }
+        info!(
+            "Time taken for userdata file in disk: {:?}",
+            start_time.elapsed()
+        );
         assert!(!record_batches.is_empty());
 
         let first_batch = &record_batches[0];

--- a/tests/src/client_server_test.rs
+++ b/tests/src/client_server_test.rs
@@ -25,9 +25,7 @@ mod tests {
         // The file dir should start from storage-node.
         // Start the server
         let server_handle = tokio::spawn(async move {
-            storage_node_serve(&"127.0.0.1".to_string(), 3030)
-                .await
-                .unwrap();
+            storage_node_serve("127.0.0.1", 3030).await.unwrap();
         });
 
         // Give the server some time to start
@@ -81,9 +79,7 @@ mod tests {
     async fn test_client_server_s3() {
         // Start the server
         let server_handle = tokio::spawn(async move {
-            storage_node_serve(&"127.0.0.1".to_string(), 3030)
-                .await
-                .unwrap();
+            storage_node_serve("127.0.0.1", 3030).await.unwrap();
         });
 
         // Give the server some time to start

--- a/tests/src/client_server_test.rs
+++ b/tests/src/client_server_test.rs
@@ -98,7 +98,13 @@ mod tests {
         assert_eq!(first_batch.num_columns(), 20);
 
         // Check the first 5 columns of the first row.
-        let real_first_row = [0.191954, 0.481544, 0.470787, 0.779391, 0.218772];
+        let real_first_row = [
+            0.19195386139992177,
+            0.4815442611405789,
+            0.47078682326631927,
+            0.7793912218913533,
+            0.21877220521846885,
+        ];
         for (i, &real_value) in real_first_row.iter().enumerate() {
             let column = first_batch
                 .column(i)

--- a/tests/src/client_server_test.rs
+++ b/tests/src/client_server_test.rs
@@ -25,7 +25,9 @@ mod tests {
         // The file dir should start from storage-node.
         // Start the server
         let server_handle = tokio::spawn(async move {
-            storage_node_serve().await.unwrap();
+            storage_node_serve(&"127.0.0.1".to_string(), 3030)
+                .await
+                .unwrap();
         });
 
         // Give the server some time to start
@@ -79,7 +81,9 @@ mod tests {
     async fn test_client_server_s3() {
         // Start the server
         let server_handle = tokio::spawn(async move {
-            storage_node_serve().await.unwrap();
+            storage_node_serve(&"127.0.0.1".to_string(), 3030)
+                .await
+                .unwrap();
         });
 
         // Give the server some time to start

--- a/tests/src/client_server_test.rs
+++ b/tests/src/client_server_test.rs
@@ -7,7 +7,6 @@ extern crate storage_node;
 #[cfg(test)]
 mod tests {
     use arrow::array::{Float64Array, StringArray};
-    use log::info;
     use serial_test::serial;
     use std::time::Instant;
     use storage_client::client::StorageClientImpl;
@@ -45,7 +44,7 @@ mod tests {
         while let Some(record_batch) = receiver.recv().await {
             record_batches.push(record_batch);
         }
-        info!(
+        println!(
             "Time taken for userdata file in disk: {:?}",
             start_time.elapsed()
         );
@@ -101,7 +100,7 @@ mod tests {
             record_batches.push(record_batch);
         }
 
-        info!("Time taken for 1m file: {:?}", start_time.elapsed());
+        println!("Time taken for 1m file: {:?}", start_time.elapsed());
         assert!(!record_batches.is_empty());
 
         let first_batch = &record_batches[0];
@@ -114,58 +113,6 @@ mod tests {
             0.47078682326631927,
             0.7793912218913533,
             0.21877220521846885,
-        ];
-        for (i, &real_value) in real_first_row.iter().enumerate() {
-            let column = first_batch
-                .column(i)
-                .as_any()
-                .downcast_ref::<Float64Array>()
-                .unwrap();
-            assert_eq!(column.value(0), real_value);
-        }
-
-        server_handle.abort();
-    }
-
-    #[tokio::test]
-    #[serial]
-    async fn test_client_server_s3_large() {
-        // Start the server
-        let server_handle = tokio::spawn(async move {
-            storage_node_serve().await.unwrap();
-        });
-
-        // Give the server some time to start
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
-
-        let storage_client =
-            StorageClientImpl::new("http://127.0.0.1:3030", "http://127.0.0.1:3031")
-                .expect("Failed to create storage client.");
-        let start_time = Instant::now();
-        // Requesting random_data_100m_0.parquet
-        let request = StorageRequest::Table(10);
-        let mut receiver = storage_client
-            .request_data(request)
-            .await
-            .expect("Failed to get data from the server.");
-        let mut record_batches = vec![];
-        while let Some(record_batch) = receiver.recv().await {
-            record_batches.push(record_batch);
-        }
-        info!("Time taken for 100m file: {:?}", start_time.elapsed());
-
-        assert!(!record_batches.is_empty());
-
-        let first_batch = &record_batches[0];
-        assert_eq!(first_batch.num_columns(), 20);
-
-        // Check the first 5 columns of the first row.
-        let real_first_row = [
-            0.869278151694903,
-            0.5698583744743971,
-            0.5731127546817466,
-            0.9509491985107434,
-            0.3949108352357301,
         ];
         for (i, &real_value) in real_first_row.iter().enumerate() {
             let column = first_batch

--- a/tests/src/client_server_test.rs
+++ b/tests/src/client_server_test.rs
@@ -98,14 +98,14 @@ mod tests {
         assert_eq!(first_batch.num_columns(), 20);
 
         // Check the first 5 columns of the first row.
-        let real_first_row = vec![0.191954, 0.481544, 0.470787, 0.779391, 0.218772];
-        for i in 0..5 {
+        let real_first_row = [0.191954, 0.481544, 0.470787, 0.779391, 0.218772];
+        for (i, &real_value) in real_first_row.iter().enumerate() {
             let column = first_batch
                 .column(i)
                 .as_any()
                 .downcast_ref::<Float64Array>()
                 .unwrap();
-            assert_eq!(column.value(0), real_first_row[i]);
+            assert_eq!(column.value(0), real_value);
         }
 
         server_handle.abort();

--- a/tests/src/client_server_test.rs
+++ b/tests/src/client_server_test.rs
@@ -33,7 +33,7 @@ mod tests {
         let storage_client =
             StorageClientImpl::new("http://127.0.0.1:3030", "http://127.0.0.1:3031")
                 .expect("Failed to create storage client.");
-        let request = StorageRequest::Table(1);
+        let request = StorageRequest::Table(0);
         let mut receiver = storage_client
             .request_data_test(request)
             .await
@@ -47,16 +47,23 @@ mod tests {
         let first_batch = &record_batches[0];
         assert_eq!(first_batch.num_columns(), 13);
 
-        let first_names = StringArray::from(vec!["Amanda", "Albert", "Evelyn"]);
-        let last_names = StringArray::from(vec!["Jordan", "Freeman", "Morgan"]);
-        assert_eq!(
-            first_batch.column(2).as_any().downcast_ref::<StringArray>(),
-            Some(&first_names)
-        );
-        assert_eq!(
-            first_batch.column(3).as_any().downcast_ref::<StringArray>(),
-            Some(&last_names)
-        );
+        let real_first_names = StringArray::from(vec!["Amanda", "Albert", "Evelyn"]);
+        let read_last_names = StringArray::from(vec!["Jordan", "Freeman", "Morgan"]);
+        let first_names = first_batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let last_names = first_batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        // Check the first three entries in the first and last name columns.
+        for i in 0..3 {
+            assert_eq!(first_names.value(i), real_first_names.value(i));
+            assert_eq!(last_names.value(i), read_last_names.value(i));
+        }
 
         server_handle.abort();
     }
@@ -89,16 +96,23 @@ mod tests {
         let first_batch = &record_batches[0];
         assert_eq!(first_batch.num_columns(), 13);
 
-        let first_names = StringArray::from(vec!["Amanda", "Albert", "Evelyn"]);
-        let last_names = StringArray::from(vec!["Jordan", "Freeman", "Morgan"]);
-        assert_eq!(
-            first_batch.column(2).as_any().downcast_ref::<StringArray>(),
-            Some(&first_names)
-        );
-        assert_eq!(
-            first_batch.column(3).as_any().downcast_ref::<StringArray>(),
-            Some(&last_names)
-        );
+        let real_first_names = StringArray::from(vec!["Amanda", "Albert", "Evelyn"]);
+        let read_last_names = StringArray::from(vec!["Jordan", "Freeman", "Morgan"]);
+        let first_names = first_batch
+            .column(2)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        let last_names = first_batch
+            .column(3)
+            .as_any()
+            .downcast_ref::<StringArray>()
+            .unwrap();
+        // Check the first three entries in the first and last name columns.
+        for i in 0..3 {
+            assert_eq!(first_names.value(i), real_first_names.value(i));
+            assert_eq!(last_names.value(i), read_last_names.value(i));
+        }
 
         server_handle.abort();
     }


### PR DESCRIPTION
1. Add a driver to benchmark transmission time for a 100MB parquet file from S3 to an EC2 instance.
1. Add a test to check the response status when the file is not found on the server's disk.
1. Add a trace generation script.
1. Use a map to mimic the catalog.
1. Decouple tests and batch size of the record batch.
