### PR TITLE
feat: enable getting object size from s3

### DIFF
--- a/storage-node/src/cache/data_store_cache/memdisk/mod.rs
+++ b/storage-node/src/cache/data_store_cache/memdisk/mod.rs
@@ -155,7 +155,7 @@ impl<R: DataStoreReplacer<MemDiskStoreReplacerKey, MemDiskStoreReplacerValue>> D
     async fn put_data_to_cache(
         &mut self,
         remote_location: String,
-        _data_size: usize,
+        _data_size: Option<usize>,
         mut data_stream: StorageReaderStream,
     ) -> ParpulseResult<usize> {
         // TODO: Refine the lock.
@@ -296,26 +296,17 @@ mod tests {
         let keys = vec!["what-can-i-hold-you-with".to_string()];
         let data1_key = bucket.clone() + &keys[0];
         let reader = MockS3Reader::new(bucket.clone(), keys.clone()).await;
-        let data_size = reader.get_object_size().await.unwrap();
+        let data_stream = reader.into_stream().await.unwrap();
         let written_data_size = cache
-            .put_data_to_cache(
-                data1_key.clone(),
-                data_size,
-                reader.into_stream().await.unwrap(),
-            )
+            .put_data_to_cache(data1_key.clone(), None, data_stream)
             .await
             .unwrap();
         assert_eq!(written_data_size, 930);
 
         let data2_key = bucket.clone() + &keys[0] + "1";
         let reader = MockS3Reader::new(bucket.clone(), keys).await;
-        let data_size = reader.get_object_size().await.unwrap();
         let mut written_data_size = cache
-            .put_data_to_cache(
-                data2_key.clone(),
-                data_size,
-                reader.into_stream().await.unwrap(),
-            )
+            .put_data_to_cache(data2_key.clone(), None, reader.into_stream().await.unwrap())
             .await
             .unwrap();
         assert_eq!(written_data_size, 930);
@@ -351,11 +342,10 @@ mod tests {
         let keys = vec!["userdata1.parquet".to_string()];
         let remote_location = bucket.clone() + &keys[0];
         let reader = MockS3Reader::new(bucket.clone(), keys).await;
-        let data_size = reader.get_object_size().await.unwrap();
         let written_data_size = cache
             .put_data_to_cache(
                 remote_location.clone(),
-                data_size,
+                None,
                 reader.into_stream().await.unwrap(),
             )
             .await
@@ -365,11 +355,10 @@ mod tests {
         let keys = vec!["userdata2.parquet".to_string()];
         let remote_location2 = bucket.clone() + &keys[0];
         let reader = MockS3Reader::new(bucket, keys).await;
-        let data_size = reader.get_object_size().await.unwrap();
         let mut written_data_size = cache
             .put_data_to_cache(
                 remote_location2.clone(),
-                data_size,
+                None,
                 reader.into_stream().await.unwrap(),
             )
             .await
@@ -407,13 +396,8 @@ mod tests {
         let keys = vec!["what-can-i-hold-you-with".to_string()];
         let data1_key = bucket.clone() + &keys[0];
         let reader = MockS3Reader::new(bucket.clone(), keys.clone()).await;
-        let data_size = reader.get_object_size().await.unwrap();
         let written_data_size = cache
-            .put_data_to_cache(
-                data1_key.clone(),
-                data_size,
-                reader.into_stream().await.unwrap(),
-            )
+            .put_data_to_cache(data1_key.clone(), None, reader.into_stream().await.unwrap())
             .await
             .unwrap();
         assert_eq!(written_data_size, 930);
@@ -422,13 +406,8 @@ mod tests {
         let keys = vec!["userdata1.parquet".to_string()];
         let data2_key = bucket.clone() + &keys[0];
         let reader = MockS3Reader::new(bucket.clone(), keys).await;
-        let data_size = reader.get_object_size().await.unwrap();
         let mut written_data_size = cache
-            .put_data_to_cache(
-                data2_key.clone(),
-                data_size,
-                reader.into_stream().await.unwrap(),
-            )
+            .put_data_to_cache(data2_key.clone(), None, reader.into_stream().await.unwrap())
             .await
             .unwrap();
         assert_eq!(written_data_size, 113629);

--- a/storage-node/src/cache/data_store_cache/mod.rs
+++ b/storage-node/src/cache/data_store_cache/mod.rs
@@ -16,6 +16,7 @@ pub trait DataStoreCache {
     async fn put_data_to_cache(
         &mut self,
         remote_location: String,
+        data_size: usize,
         data_stream: StorageReaderStream,
     ) -> ParpulseResult<usize>;
 }

--- a/storage-node/src/cache/data_store_cache/mod.rs
+++ b/storage-node/src/cache/data_store_cache/mod.rs
@@ -13,10 +13,14 @@ pub trait DataStoreCache {
         remote_location: String,
     ) -> ParpulseResult<Option<Receiver<ParpulseResult<Bytes>>>>;
 
+    /// Put data to cache. Accepts a stream of bytes and returns the number of bytes written.
+    /// The data_size parameter is optional and can be used to hint the cache about the size of the data.
+    /// If the data_size is not provided, the cache implementation should try to determine the size of
+    /// the data.
     async fn put_data_to_cache(
         &mut self,
         remote_location: String,
-        data_size: usize,
+        data_size: Option<usize>,
         data_stream: StorageReaderStream,
     ) -> ParpulseResult<usize>;
 }

--- a/storage-node/src/server.rs
+++ b/storage-node/src/server.rs
@@ -19,6 +19,7 @@ pub async fn storage_node_serve() -> ParpulseResult<()> {
     let cache = LruReplacer::new(dummy_size);
     // TODO: cache_base_path should be from config
     let data_store_cache = MemDiskStoreCache::new(cache, CACHE_BASE_PATH.to_string(), None, None);
+    let is_mem_disk_cache = true;
     // TODO: try to use more fine-grained lock instead of locking the whole storage_manager
     let storage_manager = Arc::new(Mutex::new(StorageManager::new(data_store_cache)));
 
@@ -46,7 +47,11 @@ pub async fn storage_node_serve() -> ParpulseResult<()> {
                 } else {
                     RequestParams::S3((bucket, vec![keys]))
                 };
-                let result = storage_manager.lock().await.get_data(request).await;
+                let result = storage_manager
+                    .lock()
+                    .await
+                    .get_data(request, is_mem_disk_cache)
+                    .await;
                 let data_rx = result.unwrap();
 
                 let stream = ReceiverStream::new(data_rx);

--- a/storage-node/src/storage_reader/s3_diskmock.rs
+++ b/storage-node/src/storage_reader/s3_diskmock.rs
@@ -54,6 +54,14 @@ impl MockS3Reader {
             disk_manager: DiskManager::default(),
         }
     }
+
+    pub async fn get_object_size(&self) -> ParpulseResult<usize> {
+        let mut size = 0;
+        for file_path in &self.file_paths {
+            size += self.disk_manager.file_size(&file_path).await? as usize;
+        }
+        Ok(size)
+    }
 }
 
 pub struct MockS3ReaderStream {

--- a/storage-node/src/storage_reader/s3_diskmock.rs
+++ b/storage-node/src/storage_reader/s3_diskmock.rs
@@ -58,7 +58,7 @@ impl MockS3Reader {
     pub async fn get_object_size(&self) -> ParpulseResult<usize> {
         let mut size = 0;
         for file_path in &self.file_paths {
-            size += self.disk_manager.file_size(&file_path).await? as usize;
+            size += self.disk_manager.file_size(file_path).await? as usize;
         }
         Ok(size)
     }


### PR DESCRIPTION
This PR serves as a prerequisite for #43. We need the object size before we put the data into Sqlite.