### PR TITLE
fix: fix bugs for considering eviction in parallel and others

### DIFF
--- a/storage-node/src/cache/data_store_cache/memdisk/data_store/disk.rs
+++ b/storage-node/src/cache/data_store_cache/memdisk/data_store/disk.rs
@@ -56,6 +56,7 @@ impl DiskStore {
         &self,
         key: &str,
         disk_replacer: Arc<Mutex<R>>,
+        key_replacer: String,
     ) -> ParpulseResult<Option<Receiver<ParpulseResult<Bytes>>>>
     where
         R: DataStoreReplacer<MemDiskStoreReplacerKey, MemDiskStoreReplacerValue> + 'static,
@@ -68,7 +69,6 @@ impl DiskStore {
         // FIXME: Shall we consider the situation where the data is not found?
         let mut disk_stream = self.disk_manager.disk_read_stream(key, buffer_size).await?;
         let (tx, rx) = tokio::sync::mpsc::channel(DEFAULT_DISK_CHANNEL_BUFFER_SIZE);
-        let key_str = key.to_string().clone();
         tokio::spawn(async move {
             loop {
                 match disk_stream.next().await {
@@ -78,11 +78,13 @@ impl DiskStore {
                             .unwrap();
                     }
                     Some(Err(e)) => tx.send(Err(e)).await.unwrap(),
-                    None => break,
+                    None => {
+                        // TODO(lanlou): when second read, so there is no need to unpin, how to improve?
+                        disk_replacer.lock().await.unpin(&key_replacer);
+                        break;
+                    }
                 }
             }
-            // TODO(lanlou): when second read, so there is no need to unpin, how to improve?
-            disk_replacer.lock().await.unpin(&key_str);
         });
         Ok(Some(rx))
     }

--- a/storage-node/src/cache/data_store_cache/memdisk/mod.rs
+++ b/storage-node/src/cache/data_store_cache/memdisk/mod.rs
@@ -294,7 +294,8 @@ impl<R: DataStoreReplacer<MemDiskStoreReplacerKey, MemDiskStoreReplacerValue>> D
                         }
                     }
                     Status::MemCompleted => {
-                        // not be notified
+                        // This code only applies to: a thread tries to `put_data_to_cache` but the data is already in cache
+                        // and not be evicted. It is not wait and notified situation.
                         let mut mem_replacer = self.mem_replacer.as_ref().unwrap().lock().await;
                         if mem_replacer.peek(&remote_location).is_some() {
                             mem_replacer.pin(&remote_location, 1);
@@ -303,6 +304,8 @@ impl<R: DataStoreReplacer<MemDiskStoreReplacerKey, MemDiskStoreReplacerValue>> D
                         // If mem_replacer has no data, then update status_of_keys
                     }
                     Status::DiskCompleted => {
+                        // This code only applies to: a thread tries to `put_data_to_cache` but the data is already in cache
+                        // and not be evicted. It is not wait and notified situation.
                         let mut disk_replacer = self.disk_replacer.lock().await;
                         if disk_replacer.peek(&remote_location).is_some() {
                             disk_replacer.pin(&remote_location, 1);


### PR DESCRIPTION
1. `get_data_from_cache` and `put_data_to_cache` aren't atomic. Think about one thread executes `get_data_from_cache` very early, and it is swapped out, another thread complete `put_data_from_cache` for the same key, and this thread wakes up, try to execute `put_data_from_cache`, it will poll from s3, update cache again, but there is no need. So I still want to use status_of_keys to track all the keys in the mem and disk replacer, and if it is completed, then threads can directly return, which is the most efficient way to handle it. So I fix bugs for these situations.
2. when a key in status_of_keys is set to completed, then it will forever stay in status_of_keys even if it is evicted, so some later threads cannot find data if it is evicted. We have to remove the key from status_of_keys when it is evicted.
3. During eviction from mem to disk, we need to use status_of_keys as a huge lock to lock it, otherwise eviction & write conflicts may happen
4. when main insertion progress fails, it should notify waiters
5. if no one is waiting, then we don't need to grab the lock for replacers to pin (pin_count is 0)
6. for disk_store read_data, the key to unpin replacer is wrong

TODO: when mem_replacer wants to evict A from mem to disk, is there any possibility that the status of A is incompleted? (Currently I just use continue to aviod eviction to disk and write to disk conflicts...)