### PR TITLE
feat: introduce storage node configuration

### DIFF
--- a/storage-node/Cargo.toml
+++ b/storage-node/Cargo.toml
@@ -26,6 +26,8 @@ rusqlite = { version = "0.31", features = ["blob"] }
 log = "0.4"
 env_logger = "0.11"
 crc32fast = "1.4.0"
+clap = { version = "4.5", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
 serial_test = "3.1"

--- a/storage-node/src/bin/storage_node.rs
+++ b/storage-node/src/bin/storage_node.rs
@@ -1,13 +1,16 @@
 use log::info;
-use storage_node::server::storage_node_serve;
-
-// TODO: Add config here.
+use storage_node::{common::config::ParpulseConfig, server::storage_node_serve};
 
 #[tokio::main]
 async fn main() {
-    let _ = env_logger::builder()
+    // Init log.
+    if let Err(e) = env_logger::builder()
         .filter_level(log::LevelFilter::Info)
-        .try_init();
+        .try_init()
+    {
+        println!("Failed to init logger: {:?}", e);
+    }
     info!("starting storage node server...");
-    storage_node_serve("0.0.0.0", 3030).await.unwrap();
+    let config = ParpulseConfig::parse();
+    storage_node_serve("0.0.0.0", 3030, config).await.unwrap();
 }

--- a/storage-node/src/bin/storage_node.rs
+++ b/storage-node/src/bin/storage_node.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use log::info;
 use storage_node::{common::config::ParpulseConfig, server::storage_node_serve};
 

--- a/storage-node/src/cache/data_store_cache/memdisk/mod.rs
+++ b/storage-node/src/cache/data_store_cache/memdisk/mod.rs
@@ -602,7 +602,7 @@ mod tests {
             LruReplacer::new(1024 * 512),
             disk_base_path.to_str().unwrap().to_string(),
             Some(LruReplacer::new(950)),
-            None,
+            Some(10 * 1024),
         );
         let bucket = "tests-text".to_string();
         let keys = vec!["what-can-i-hold-you-with".to_string()];

--- a/storage-node/src/cache/data_store_cache/memdisk/mod.rs
+++ b/storage-node/src/cache/data_store_cache/memdisk/mod.rs
@@ -106,9 +106,10 @@ impl<R: DataStoreReplacer<MemDiskStoreReplacerKey, MemDiskStoreReplacerValue>>
         disk_base_path: String,
         mem_replacer: Option<R>,
         mem_max_file_size: Option<usize>,
+        max_disk_reader_buffer_size: usize,
     ) -> Self {
         let disk_manager = DiskManager::default();
-        let disk_store = DiskStore::new(disk_manager, disk_base_path);
+        let disk_store = DiskStore::new(disk_manager, disk_base_path, max_disk_reader_buffer_size);
 
         if mem_replacer.is_some() {
             debug_assert!(mem_max_file_size.is_some());
@@ -614,6 +615,7 @@ mod tests {
             disk_base_path.to_str().unwrap().to_string(),
             Some(LruReplacer::new(120000)),
             Some(10 * 1024),
+            512,
         );
         let bucket = "tests-parquet".to_string();
         let keys = vec!["userdata1.parquet".to_string()];
@@ -652,6 +654,7 @@ mod tests {
             disk_base_path.to_str().unwrap().to_string(),
             None,
             None,
+            512,
         );
         let bucket = "tests-parquet".to_string();
         let keys = vec!["userdata1.parquet".to_string()];
@@ -686,6 +689,7 @@ mod tests {
             disk_base_path.to_str().unwrap().to_string(),
             Some(LruReplacer::new(950)),
             Some(950),
+            512,
         );
         let bucket = "tests-text".to_string();
         let keys = vec!["what-can-i-hold-you-with".to_string()];
@@ -725,6 +729,7 @@ mod tests {
             disk_base_path.to_str().unwrap().to_string(),
             None,
             None,
+            512,
         ));
         let bucket = "tests-parquet".to_string();
         let keys = vec!["userdata2.parquet".to_string()];
@@ -760,6 +765,7 @@ mod tests {
             disk_base_path.to_str().unwrap().to_string(),
             Some(LruReplacer::new(120000)),
             Some(120000),
+            512,
         ));
         let bucket = "tests-parquet".to_string();
         let keys = vec!["userdata1.parquet".to_string()];

--- a/storage-node/src/cache/data_store_cache/memdisk/mod.rs
+++ b/storage-node/src/cache/data_store_cache/memdisk/mod.rs
@@ -22,11 +22,6 @@ use tokio::sync::mpsc::Receiver;
 
 use self::data_store::{disk::DiskStore, memory::MemStore};
 
-/// The default maximum single file size for the memory cache.
-/// If the file size exceeds this value, the file will be stored in the disk cache.
-/// TODO(lanlou): make this value configurable.
-pub const DEFAULT_MEM_CACHE_MAX_FILE_SIZE: usize = 1024 * 512;
-
 /// [`MemDiskStoreReplacerKey`] is a path to the remote object store.
 pub type MemDiskStoreReplacerKey = String;
 
@@ -113,8 +108,8 @@ impl<R: DataStoreReplacer<MemDiskStoreReplacerKey, MemDiskStoreReplacerValue>>
         let disk_store = DiskStore::new(disk_manager, disk_base_path);
 
         if mem_replacer.is_some() {
-            let mut mem_max_file_size =
-                mem_max_file_size.unwrap_or(DEFAULT_MEM_CACHE_MAX_FILE_SIZE);
+            debug_assert!(mem_max_file_size.is_some());
+            let mut mem_max_file_size = mem_max_file_size.unwrap();
             let replacer_max_capacity = mem_replacer.as_ref().unwrap().max_capacity();
             if mem_max_file_size > replacer_max_capacity {
                 warn!("The maximum file size > replacer's max capacity, so we set maximum file size = 1/5 of the maximum capacity.");

--- a/storage-node/src/cache/replacer/mod.rs
+++ b/storage-node/src/cache/replacer/mod.rs
@@ -3,13 +3,6 @@ pub mod lru_k;
 use std::fmt::Debug;
 use std::hash::Hash;
 
-use self::{lru::LruReplacer, lru_k::LruKReplacer};
-
-use super::data_store_cache::{
-    memdisk::{MemDiskStoreReplacerKey, MemDiskStoreReplacerValue},
-    sqlite::{SqliteStoreReplacerKey, SqliteStoreReplacerValue},
-};
-
 /// [`ReplacerKey`] is the key type for data store replacers using different
 /// policies in the system.
 pub trait ReplacerKey: Hash + Eq + Clone + Debug + Send + Sync {}
@@ -65,81 +58,6 @@ pub trait DataStoreReplacer<K: ReplacerKey, V: ReplacerValue>: Send + Sync {
     fn set_max_capacity(&mut self, capacity: usize);
 
     fn clear(&mut self);
-}
-
-pub enum ParpulseDataStoreReplacerKey {
-    MemDiskStoreReplacerKey(MemDiskStoreReplacerKey),
-    SqliteStoreReplacerKey(SqliteStoreReplacerKey),
-}
-
-pub enum ParpulseDataStoreReplacerValue {
-    MemDiskStoreReplacerValue(MemDiskStoreReplacerValue),
-    SqliteStoreReplacerValue(SqliteStoreReplacerValue),
-}
-
-pub enum ParpulseDataStoreReplacer {
-    MemDiskLruReplacer(LruReplacer<MemDiskStoreReplacerKey, MemDiskStoreReplacerValue>),
-    MemDiskLruKReplacer(LruKReplacer<MemDiskStoreReplacerKey, MemDiskStoreReplacerValue>),
-    SqliteLruReplacer(LruReplacer<SqliteStoreReplacerKey, SqliteStoreReplacerValue>),
-    SqliteLruKReplacer(LruKReplacer<SqliteStoreReplacerKey, SqliteStoreReplacerValue>),
-}
-
-impl DataStoreReplacer<ParpulseDataStoreReplacerKey, ParpulseDataStoreReplacerValue>
-    for ParpulseDataStoreReplacer
-{
-    fn get(&mut self, key: &K) -> Option<&V> {
-        match self {
-            ParpulseDataStoreReplacer::MemDiskLruReplacer(replacer) => replacer.get(key),
-            ParpulseDataStoreReplacer::MemDiskLruKReplacer(replacer) => replacer.get(key),
-            ParpulseDataStoreReplacer::SqliteLruReplacer(replacer) => replacer.get(key),
-            ParpulseDataStoreReplacer::SqliteLruKReplacer(replacer) => replacer.get(key),
-        }
-    }
-
-    fn put(&mut self, key: K, value: V) -> Option<Vec<K>> {
-        match self {
-            ParpulseDataStoreReplacer::MemDiskLruReplacer(replacer) => replacer.put(key, value),
-            ParpulseDataStoreReplacer::MemDiskLruKReplacer(replacer) => replacer.put(key, value),
-            ParpulseDataStoreReplacer::SqliteLruReplacer(replacer) => replacer.put(key, value),
-            ParpulseDataStoreReplacer::SqliteLruKReplacer(replacer) => replacer.put(key, value),
-        }
-    }
-
-    fn pin(&mut self, key: &K, count: usize) -> bool {
-        todo!()
-    }
-
-    fn unpin(&mut self, key: &K) -> bool {
-        todo!()
-    }
-
-    fn peek(&self, key: &K) -> Option<&V> {
-        todo!()
-    }
-
-    fn len(&self) -> usize {
-        todo!()
-    }
-
-    fn size(&self) -> usize {
-        todo!()
-    }
-
-    fn is_empty(&self) -> bool {
-        todo!()
-    }
-
-    fn max_capacity(&self) -> usize {
-        todo!()
-    }
-
-    fn set_max_capacity(&mut self, capacity: usize) {
-        todo!()
-    }
-
-    fn clear(&mut self) {
-        todo!()
-    }
 }
 
 #[cfg(test)]

--- a/storage-node/src/cache/replacer/mod.rs
+++ b/storage-node/src/cache/replacer/mod.rs
@@ -3,6 +3,13 @@ pub mod lru_k;
 use std::fmt::Debug;
 use std::hash::Hash;
 
+use self::{lru::LruReplacer, lru_k::LruKReplacer};
+
+use super::data_store_cache::{
+    memdisk::{MemDiskStoreReplacerKey, MemDiskStoreReplacerValue},
+    sqlite::{SqliteStoreReplacerKey, SqliteStoreReplacerValue},
+};
+
 /// [`ReplacerKey`] is the key type for data store replacers using different
 /// policies in the system.
 pub trait ReplacerKey: Hash + Eq + Clone + Debug + Send + Sync {}
@@ -58,6 +65,81 @@ pub trait DataStoreReplacer<K: ReplacerKey, V: ReplacerValue>: Send + Sync {
     fn set_max_capacity(&mut self, capacity: usize);
 
     fn clear(&mut self);
+}
+
+pub enum ParpulseDataStoreReplacerKey {
+    MemDiskStoreReplacerKey(MemDiskStoreReplacerKey),
+    SqliteStoreReplacerKey(SqliteStoreReplacerKey),
+}
+
+pub enum ParpulseDataStoreReplacerValue {
+    MemDiskStoreReplacerValue(MemDiskStoreReplacerValue),
+    SqliteStoreReplacerValue(SqliteStoreReplacerValue),
+}
+
+pub enum ParpulseDataStoreReplacer {
+    MemDiskLruReplacer(LruReplacer<MemDiskStoreReplacerKey, MemDiskStoreReplacerValue>),
+    MemDiskLruKReplacer(LruKReplacer<MemDiskStoreReplacerKey, MemDiskStoreReplacerValue>),
+    SqliteLruReplacer(LruReplacer<SqliteStoreReplacerKey, SqliteStoreReplacerValue>),
+    SqliteLruKReplacer(LruKReplacer<SqliteStoreReplacerKey, SqliteStoreReplacerValue>),
+}
+
+impl DataStoreReplacer<ParpulseDataStoreReplacerKey, ParpulseDataStoreReplacerValue>
+    for ParpulseDataStoreReplacer
+{
+    fn get(&mut self, key: &K) -> Option<&V> {
+        match self {
+            ParpulseDataStoreReplacer::MemDiskLruReplacer(replacer) => replacer.get(key),
+            ParpulseDataStoreReplacer::MemDiskLruKReplacer(replacer) => replacer.get(key),
+            ParpulseDataStoreReplacer::SqliteLruReplacer(replacer) => replacer.get(key),
+            ParpulseDataStoreReplacer::SqliteLruKReplacer(replacer) => replacer.get(key),
+        }
+    }
+
+    fn put(&mut self, key: K, value: V) -> Option<Vec<K>> {
+        match self {
+            ParpulseDataStoreReplacer::MemDiskLruReplacer(replacer) => replacer.put(key, value),
+            ParpulseDataStoreReplacer::MemDiskLruKReplacer(replacer) => replacer.put(key, value),
+            ParpulseDataStoreReplacer::SqliteLruReplacer(replacer) => replacer.put(key, value),
+            ParpulseDataStoreReplacer::SqliteLruKReplacer(replacer) => replacer.put(key, value),
+        }
+    }
+
+    fn pin(&mut self, key: &K, count: usize) -> bool {
+        todo!()
+    }
+
+    fn unpin(&mut self, key: &K) -> bool {
+        todo!()
+    }
+
+    fn peek(&self, key: &K) -> Option<&V> {
+        todo!()
+    }
+
+    fn len(&self) -> usize {
+        todo!()
+    }
+
+    fn size(&self) -> usize {
+        todo!()
+    }
+
+    fn is_empty(&self) -> bool {
+        todo!()
+    }
+
+    fn max_capacity(&self) -> usize {
+        todo!()
+    }
+
+    fn set_max_capacity(&mut self, capacity: usize) {
+        todo!()
+    }
+
+    fn clear(&mut self) {
+        todo!()
+    }
 }
 
 #[cfg(test)]

--- a/storage-node/src/common/config.rs
+++ b/storage-node/src/common/config.rs
@@ -1,0 +1,43 @@
+use clap::Parser;
+use serde::Serialize;
+
+#[derive(clap::ValueEnum, Clone, Default, Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ParpulseConfigDataStore {
+    #[default]
+    Memdisk,
+    Disk,
+    Sqlite,
+}
+
+#[derive(clap::ValueEnum, Clone, Default, Debug, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ParpulseConfigCachePolicy {
+    #[default]
+    Lru,
+    Lruk,
+}
+
+#[derive(Parser)]
+pub struct ParpulseConfig {
+    #[clap(short, long, default_value_t, value_enum)]
+    pub cache_policy: ParpulseConfigCachePolicy,
+
+    #[clap(short, long, default_value = None)]
+    pub cache_lru_k: Option<usize>,
+
+    #[clap(short, long, default_value_t, value_enum)]
+    pub data_store: ParpulseConfigDataStore,
+
+    #[clap(short, long, default_value = "3")]
+    pub data_store_cache_num: usize,
+
+    #[clap(short, long, default_value = None)]
+    pub mem_cache_size: Option<usize>,
+
+    #[clap(short, long, default_value = None)]
+    pub disk_cache_size: Option<usize>,
+
+    #[clap(short, long, default_value = None)]
+    pub cache_path: Option<String>,
+}

--- a/storage-node/src/common/config.rs
+++ b/storage-node/src/common/config.rs
@@ -34,6 +34,9 @@ pub struct ParpulseConfig {
     pub mem_cache_size: Option<usize>,
 
     #[clap(long, default_value = None)]
+    pub mem_cache_file_size: Option<usize>,
+
+    #[clap(long, default_value = None)]
     pub disk_cache_size: Option<usize>,
 
     #[clap(long, default_value = None)]

--- a/storage-node/src/common/config.rs
+++ b/storage-node/src/common/config.rs
@@ -42,6 +42,12 @@ pub struct ParpulseConfig {
     #[clap(long, default_value = None)]
     pub sqlite_cache_size: Option<usize>,
 
-    #[clap( long, default_value = None)]
+    #[clap(long, default_value = None)]
     pub cache_path: Option<String>,
+
+    #[clap(long, default_value = None)]
+    pub max_disk_reader_buffer_size: Option<usize>,
+
+    #[clap(long, default_value = None)]
+    pub sqlite_blob_reader_buffer_size: Option<usize>,
 }

--- a/storage-node/src/common/config.rs
+++ b/storage-node/src/common/config.rs
@@ -2,7 +2,6 @@ use clap::Parser;
 use serde::Serialize;
 
 #[derive(clap::ValueEnum, Clone, Default, Debug, Serialize)]
-#[serde(rename_all = "kebab-case")]
 pub enum ParpulseConfigDataStore {
     #[default]
     Memdisk,
@@ -11,33 +10,35 @@ pub enum ParpulseConfigDataStore {
 }
 
 #[derive(clap::ValueEnum, Clone, Default, Debug, Serialize)]
-#[serde(rename_all = "kebab-case")]
 pub enum ParpulseConfigCachePolicy {
     #[default]
     Lru,
     Lruk,
 }
 
-#[derive(Parser)]
+#[derive(Parser, Default)]
 pub struct ParpulseConfig {
-    #[clap(short, long, default_value_t, value_enum)]
+    #[clap(long, default_value_t, value_enum)]
     pub cache_policy: ParpulseConfigCachePolicy,
 
-    #[clap(short, long, default_value = None)]
+    #[clap(long, default_value = None)]
     pub cache_lru_k: Option<usize>,
 
-    #[clap(short, long, default_value_t, value_enum)]
+    #[clap(long, default_value_t, value_enum)]
     pub data_store: ParpulseConfigDataStore,
 
-    #[clap(short, long, default_value = "3")]
-    pub data_store_cache_num: usize,
+    #[clap( long, default_value = None)]
+    pub data_store_cache_num: Option<usize>,
 
-    #[clap(short, long, default_value = None)]
+    #[clap(long, default_value = None)]
     pub mem_cache_size: Option<usize>,
 
-    #[clap(short, long, default_value = None)]
+    #[clap(long, default_value = None)]
     pub disk_cache_size: Option<usize>,
 
-    #[clap(short, long, default_value = None)]
+    #[clap(long, default_value = None)]
+    pub sqlite_cache_size: Option<usize>,
+
+    #[clap( long, default_value = None)]
     pub cache_path: Option<String>,
 }

--- a/storage-node/src/common/mod.rs
+++ b/storage-node/src/common/mod.rs
@@ -1,1 +1,2 @@
+pub mod config;
 pub mod hash;

--- a/storage-node/src/storage_manager.rs
+++ b/storage-node/src/storage_manager.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cache::data_store_cache::DataStoreCache,
+    cache::{data_store_cache::DataStoreCache, replacer::ParpulseDataStoreReplacer},
     common::hash::calculate_hash_crc32fast,
     error::ParpulseResult,
     storage_reader::{s3::S3Reader, s3_diskmock::MockS3Reader, AsyncStorageReader},
@@ -16,13 +16,13 @@ use tokio::sync::mpsc::Receiver;
 /// which should be responsible for handling multiple requests at the
 /// same time.
 
-pub struct StorageManager<C: DataStoreCache> {
+pub struct StorageManager {
     /// We don't use lock here because `data_store_cache` itself should handle the concurrency.
-    data_store_caches: Vec<C>,
+    data_store_caches: Vec<ParpulseDataStoreReplacer>,
 }
 
-impl<C: DataStoreCache> StorageManager<C> {
-    pub fn new(data_store_caches: Vec<C>) -> Self {
+impl StorageManager {
+    pub fn new(data_store_caches: Vec<ParpulseDataStoreReplacer>) -> Self {
         Self { data_store_caches }
     }
 

--- a/storage-node/src/storage_manager.rs
+++ b/storage-node/src/storage_manager.rs
@@ -119,8 +119,13 @@ mod tests {
         let dir = tmp.path().to_owned();
         let cache_base_path = dir.join("test-storage-manager");
 
-        let data_store_cache =
-            MemDiskStoreCache::new(cache, cache_base_path.display().to_string(), None, None);
+        let data_store_cache = MemDiskStoreCache::new(
+            cache,
+            cache_base_path.display().to_string(),
+            None,
+            None,
+            100 * 1024 * 1024,
+        );
         let storage_manager = StorageManagerImpl::new(vec![data_store_cache]);
 
         let bucket = "tests-parquet".to_string();
@@ -176,6 +181,7 @@ mod tests {
             disk_cache_base_path.display().to_string(),
             Some(mem_cache),
             Some(950),
+            100 * 1024 * 1024,
         );
         let storage_manager = StorageManagerImpl::new(vec![data_store_cache]);
 
@@ -235,6 +241,7 @@ mod tests {
             disk_cache_base_path.display().to_string(),
             Some(mem_cache),
             Some(120000),
+            100 * 1024 * 1024,
         );
         let storage_manager = StorageManagerImpl::new(vec![data_store_cache]);
 
@@ -286,6 +293,7 @@ mod tests {
             disk_cache_base_path.display().to_string(),
             None,
             None,
+            100 * 1024 * 1024,
         );
         let storage_manager = Arc::new(StorageManagerImpl::new(vec![data_store_cache]));
 
@@ -346,6 +354,7 @@ mod tests {
             disk_cache_base_path.display().to_string(),
             Some(mem_cache),
             Some(120000),
+            100 * 1024 * 1024,
         );
         let storage_manager = Arc::new(StorageManagerImpl::new(vec![data_store_cache]));
 
@@ -474,6 +483,7 @@ mod tests {
                 disk_cache_base_path.display().to_string(),
                 Some(mem_cache),
                 Some(120000),
+                100 * 1024 * 1024,
             );
             data_store_caches.push(data_store_cache);
         }
@@ -524,6 +534,7 @@ mod tests {
                 disk_cache_base_path.display().to_string(),
                 Some(mem_cache),
                 Some(120000),
+                100 * 1024 * 1024,
             );
             data_store_caches.push(data_store_cache);
         }
@@ -613,6 +624,7 @@ mod tests {
             disk_cache_base_path.display().to_string(),
             None,
             None,
+            100 * 1024 * 1024,
         );
         let storage_manager = Arc::new(StorageManagerImpl::new(vec![data_store_cache]));
 
@@ -648,6 +660,7 @@ mod tests {
             disk_cache_base_path.display().to_string(),
             Some(mem_cache),
             Some(120000),
+            100 * 1024 * 1024,
         );
         let storage_manager = Arc::new(StorageManagerImpl::new(vec![data_store_cache]));
 

--- a/tests/src/client_server_test.rs
+++ b/tests/src/client_server_test.rs
@@ -10,7 +10,7 @@ mod tests {
     use parpulse_client::client::StorageClientImpl;
     use serial_test::serial;
     use std::time::Instant;
-    use storage_node::server::storage_node_serve;
+    use storage_node::{common::config::ParpulseConfig, server::storage_node_serve};
 
     #[test]
     fn setup() {
@@ -26,7 +26,9 @@ mod tests {
         // The file dir should start from storage-node.
         // Start the server
         let server_handle = tokio::spawn(async move {
-            storage_node_serve("127.0.0.1", 3030).await.unwrap();
+            storage_node_serve("127.0.0.1", 3030, ParpulseConfig::default())
+                .await
+                .unwrap();
         });
 
         // Give the server some time to start
@@ -80,7 +82,9 @@ mod tests {
     async fn test_client_server_s3() {
         // Start the server
         let server_handle = tokio::spawn(async move {
-            storage_node_serve("127.0.0.1", 3030).await.unwrap();
+            storage_node_serve("127.0.0.1", 3030, ParpulseConfig::default())
+                .await
+                .unwrap();
         });
 
         // Give the server some time to start


### PR DESCRIPTION
We can run the storage node as follows:

```
cargo run -- --data-store memdisk --disk-cache-size 1000000 --mem-cache-size 1000 --cache-path "my-cache" --max-disk-reader-buffer-size 10000000
```

See `config.rs` for more configurable fields.